### PR TITLE
Add basic unit suffix support

### DIFF
--- a/CalcForge/Evaluator/Evaluator.cs
+++ b/CalcForge/Evaluator/Evaluator.cs
@@ -2,6 +2,7 @@
 using CalcForge.Func;
 using CalcForge.Tokenilzer;
 using CalcForge.TokenObjects;
+using CalcForge;
 using System.Reflection;
 namespace CalcForge.Evalutor;
 
@@ -12,7 +13,8 @@ public partial class Evaluator
     private string StringInput;
     public Evaluator(string Input)
     {
-       var splitTokens =  Tokenizer.Tokenize(StringInput = Input);
+       StringInput = UnitParser.ConvertUnits(Input);
+       var splitTokens =  Tokenizer.Tokenize(StringInput);
        _tokens = Parser.Parser.Parse(splitTokens);
     }
 

--- a/CalcForge/UnitParser.cs
+++ b/CalcForge/UnitParser.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace CalcForge;
+
+public static class UnitParser
+{
+    private static readonly Dictionary<string, double> UnitFactors = new()
+    {
+        ["mm"] = 1.0,
+        ["cm"] = 10.0,
+        ["m"] = 1000.0,
+        ["in"] = 25.4,
+        ["ft"] = 304.8
+    };
+
+    private static readonly Regex UnitRegex = new(@"(\d+(?:\.\d+)?)(mm|cm|m|in|ft)\b", RegexOptions.IgnoreCase);
+
+    public static string ConvertUnits(string input)
+    {
+        return UnitRegex.Replace(input, match =>
+        {
+            double value = double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+            string unit = match.Groups[2].Value.ToLowerInvariant();
+            if (!UnitFactors.TryGetValue(unit, out double factor))
+                return match.Value;
+            double converted = value * factor;
+            return converted.ToString(CultureInfo.InvariantCulture);
+        });
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Evtor is a lightweight, extensible C# library for parsing and evaluating complex
 * **Token optimization**: constant folding (`0+X`, `X*1`, `(2+3+4)`) and group simplification.
 * **Tree visualization**: pretty-print tokens/groups with `WriteTree` or raw tokens with `WriteTokens`.
 * **Assembly compilation**: compile token trees into MASM-style `.asm` using register reuse and opcode profiles.
+* **Unit suffix parsing**: numbers with `mm`, `cm`, `m`, `in`, or `ft` are automatically converted.
 
 ---
 
@@ -86,6 +87,9 @@ Console.WriteLine(new Evaluator("Sin(90) + Cos(0)").Evaluate());
 
 // Deep nesting
 Console.WriteLine(new Evaluator("Add(1, Add(2, Add(3, Add(4, Add(5, 6)))))").Evaluate());
+
+// Numbers with units
+Console.WriteLine(new Evaluator("28mm * 2ft").Evaluate()); // 17068.8
 ```
 
 ---


### PR DESCRIPTION
## Summary
- parse numbers with unit suffixes using `UnitParser`
- convert units like `mm`, `cm`, `m`, `in`, `ft` before tokenizing
- expose unit suffix example in README

## Testing
- `dotnet build CalcForge.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f41662af0832eb9390d4db360aa2e